### PR TITLE
Improving introductory information in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,13 @@ You define your business entities with JSON schemas. There are two ways to defin
 Regardless of your preferred option, you should structure your package according to the following template:
 
 ```
----business_entities_schemas
-        init.py 
-        ------  business_entity1
-                    ------- business_entity1_v1.json
-                    ------- business_entity1_v2.json    
-        ------  business_entity2
+.
+└── business_entities_schemas
+    ├── init.py 
+    ├── business_entity1
+    │   ├── business_entity1_v1.json
+    │   └── business_entity1_v2.json    
+    └── business_entity2
 ```
 
 You can also refer to the sample in the default [Herbie schema repostory](https://github.com/project-a/herbie-json-schema) as a guideline.
@@ -108,13 +109,14 @@ You can also refer to the sample in the default [Herbie schema repostory](https:
 This sample contains schema definitions for the business entities 'customer' and 'product':
 
 ```
----herbie-json-schema
-        init.py
-        ------  customer
-                    ------- customer_v1.json
-                    ------- customer_v2.json    
-        ------  product
-                    ------- product_v1.json
+.
+└── herbie-json-schema
+    ├── init.py
+    ├── customer
+    │   ├── customer_v1.json
+    │   └── customer_v2.json    
+    └── product
+        └── product_v1.json
 ```
 
 


### PR DESCRIPTION
- I improved the general description of Herbie to be more accessible to a wider audience.

- The quick start in the README wasn't really a quick start, since you couldn't actually log in to the admin console, and the URL was wrong anyway.

- I update the URL and added steps that show you how to create your first admin user so that you can actually log in.

I basically edited everything up to the procedure "Run Herbie on Docker".

(The procedure "Run Herbie on Docker" and all the content that follows it could still be improved, but I will do that in a follow-up round.)

I also added fixes suggested by Lars here: https://github.com/project-a/herbie/pull/128